### PR TITLE
Add SSL to security/privacy play.

### DIFF
--- a/_includes/play11.md
+++ b/_includes/play11.md
@@ -13,6 +13,7 @@ The following checklist provides a starting point, but teams should work closely
 4. Consider whether the user should be able to access, delete, or remove their information from the service
 5. “Pre-certify” the hosting infrastructure used for the project using FedRAMP
 6. Use deployment scripts to ensure configuration of production environment remains consistent and controllable
+7. Encrypt all user communications with your site with SSL by default.
 
 #### key questions
 - Does the service collect personal information from the user (whether government or public)?  How is the user notified of this collection?


### PR DESCRIPTION
There's a whole host of reasons why it makes sense for all government websites to default to SSL encryption.  It ensures that all user interactions with the site are encrypted, giving citizens more confidence in your application.  It ensures that your content will be visible to more users, as many corporate networks block unsecured sites for security reasons (fun fact: many government websites are inaccessible to the employees of the agency that operates those sites).  And it's now viewed as an important criteria for inclusion and ranking in major search engines like Google.  I'm sure there are additional reasons as well, but the bottom line is that defaulting to SSL encryption might be the best thing one can do to enhance and protect users and their privacy.

I tried to make the language succinct and clear, but more than happy if someone can say it better, if this is of interest.
