### PR TITLE
Preserve browser history and humanize anchor title

### DIFF
--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -43,7 +43,7 @@ $(function(){
         $('html,body').animate({
           scrollTop: target.offset().top
         }, 1000);
-        return false;
+        return true;
       }
     }
   });

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
         {% endfor %}
       </ul>
       <div id="menu_icon">
-        <a href="#plays_index_anchor" title="Return to Index"></a>
+        <a href="#plays" title="Return to Index"></a>
       </div>
     </div>
   </div>
@@ -35,7 +35,7 @@
       {% capture introduction %}{% include introduction.md %}{% endcapture %}
       {{ introduction | markdownify }}
       <div class="button">
-        <a href="#plays_index_anchor" title="View the Plays">SEE THE PLAYS</a>
+        <a href="#plays" title="View the Plays">SEE THE PLAYS</a>
       </div>
       <div class="button">
         <a href="https://github.com/whitehouse/playbook#readme" title="Visit Github to Improve This Content">HELP IMPROVE THIS CONTENT</a>
@@ -47,7 +47,7 @@
 <div id="plays_index">
   <div class="outer_container">
     <div class="inner_container">
-      <a class="anchor_offset" id="plays_index_anchor"></a>
+      <a class="anchor_offset" id="plays"></a>
       <h3>DIGITAL SERVICE PLAYS</h3>
       <div class="columns">
         <ol>


### PR DESCRIPTION
The scroll animation hijacked the link action and prevented the browser history from being updated (perhaps this was intended?). As a result it breaks the back button and makes it more difficult for the user to link to specific sections of content.

I also renamed one of the section's anchor tags. https://playbook.cio.gov/#plays seems a bit more aesthetically pleasing than https://playbook.cio.gov/#plays_index_anchor. I'd also consider renaming the id's of the play sections based on their titles (e.g. https://playbook.cio.gov/#1-understand-what-people-need).
