### PR TITLE
Ease collaboration by adopting same tools

### DIFF
--- a/_plays/08.md
+++ b/_plays/08.md
@@ -10,6 +10,7 @@ The technology decisions we make need to enable development teams to work effici
 2. To the extent practical, ensure that software can be deployed on a variety of commodity hardware types
 3. Ensure that each project has easy to understand instructions for setting up a local development environment, and that team members can be quickly added or removed from projects
 4. Consider open source software solutions at all layers of the stack
+5. Adopt the tools used by the same community, such as version control and issue trackers, to ease collaboration
 
 #### key questions
 - What is your development stack and why did you choose it?


### PR DESCRIPTION
When using a different stack of development tools it's much harder to contribute back/collaborate with the relevant developer community. Using the same tools makes "default to open" more practical.
