### PR TITLE
Update all github.com/whitehouse links to the newer usds repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ One way to advance smarter digital service delivery is by putting the right proc
 - [**The TechFAR Handbook**](https://techfarhub.cio.gov/handbook/ "Link to the TechFAR Handbook") highlights the flexibilities in the Federal Acquisition Regulation (FAR) that can help agencies implement “plays” from the Playbook that would be accomplished with acquisition support – with a particular focus on how to use contractors to support an iterative, customer-driven software development process, as is routinely done in the private sector.
 
 ## We Want Your Feedback
-We encourage your feedback and suggestions on these documents. Content and feature suggestions and discussions are welcome via [GitHub Issues](https://github.com/WhiteHouse/playbook/issues). You may also propose changes to the content directly by submitting a [pull request](https://help.github.com/articles/creating-a-pull-request "More Information on Submitting Pull Requests").
+We encourage your feedback and suggestions on these documents. Content and feature suggestions and discussions are welcome via [GitHub Issues](https://github.com/usds/playbook/issues). You may also propose changes to the content directly by submitting a [pull request](https://help.github.com/articles/creating-a-pull-request "More Information on Submitting Pull Requests").
 
 You don't need to install any software to suggest a change. To propose a change from your browser, [select a play in the `_plays` folder](https://github.com/usds/playbook/tree/gh-pages/_plays "Link to the Plays Markdown files"). You can use GitHub's in-browser editor to edit files and submit a "pull request" for your changes to be merged into the document.
 
-If you would like to see and discuss the changes that other people have proposed, [visit the "Pull Requests" section](https://github.com/usds/playbook/pulls "Link to the Pull Requests Section of GitHub") and [browse the issues](https://github.com/WhiteHouse/playbook/issues "Link to the Issues Section of GitHub").
+If you would like to see and discuss the changes that other people have proposed, [visit the "Pull Requests" section](https://github.com/usds/playbook/pulls "Link to the Pull Requests Section of GitHub") and [browse the issues](https://github.com/usds/playbook/issues "Link to the Issues Section of GitHub").
 
 ## Technical Details
 
-The Playbook is compiled from [Markdown](https://help.github.com/articles/github-flavored-markdown "Link to More Information About Markdown") files using [Jekyll](https://github.com/jekyll/jekyll "Link to More Information about Jekyll"). To propose a specific change, you can submit a [pull request](https://help.github.com/articles/creating-a-pull-request "More Information on Submitting Pull Requests") with your change to one of these source Markdown files. The Plays from the Playbook are [available in the `_plays` folder](https://github.com/WhiteHouse/playbook/tree/gh-pages/_plays "Link to the Plays Markdown files").
+The Playbook is compiled from [Markdown](https://help.github.com/articles/github-flavored-markdown "Link to More Information About Markdown") files using [Jekyll](https://github.com/jekyll/jekyll "Link to More Information about Jekyll"). To propose a specific change, you can submit a [pull request](https://help.github.com/articles/creating-a-pull-request "More Information on Submitting Pull Requests") with your change to one of these source Markdown files. The Plays from the Playbook are [available in the `_plays` folder](https://github.com/usds/playbook/tree/gh-pages/_plays "Link to the Plays Markdown files").
 
 You can also use Github's in-browser editing feature to make an edit to one of these Markdown files and submit your change for consideration without needing to install any additional software.
 

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
         <a href="#plays_index_anchor" title="View the Plays">See the plays</a>
       </div>
       <div class="button">
-        <a href="https://github.com/whitehouse/playbook#readme" title="Visit Github to Improve This Content">Help improve this content</a>
+        <a href="https://github.com/usds/playbook#readme" title="Visit Github to Improve This Content">Help improve this content</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This updates all instances of `github.com/whitehouse` (the old repo) to `github.com/usds` (the newer repo). The old `whitehouse` repo currently auto-forwards, so the links aren't broken per se, but that's not great to rely on forever.